### PR TITLE
Various improvements to the PKGBUILD; trying to define a standard ?

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,12 +5,13 @@
 pkgname=ame
 _pkgname=amethyst
 pkgver=4.0.0
-pkgrel=2
+pkgrel=3
+_codename='Funky Fish'
 pkgdesc='A fast and efficient AUR helper'
 arch=('x86_64' 'aarch64')
-url="https://github.com/crystal-linux/$_pkgname"
+url="https://github.com/crystal-linux/${_pkgname}"
 license=('GPL3')
-source=("$_pkgname-$pkgver-$pkgrel::$url/archive/v$pkgver.tar.gz")
+source=("${_pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
 sha256sums=('ae1e6336177b6fa64536c9a8876ba0bac510ac528153133b67cf3f5046b43583')
 depends=(
     'git'
@@ -26,21 +27,21 @@ conflicts=('amethyst')
 replaces=('amethyst')
 
 prepare() {
-    cd "$srcdir/$_pkgname-$pkgver"
-    cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+    cd "${srcdir}/${_pkgname}-${pkgver}"
+    cargo fetch --locked --target "${CARCH}-unknown-linux-gnu"
 }
 
 build() {
-    cd "$srcdir/$_pkgname-$pkgver"
+    cd "${srcdir}/${_pkgname}-${pkgver}"
     export RUSTUP_TOOLCHAIN=nightly
     export CARGO_TARGET_DIR=target
-    export AMETHYST_CODENAME="Funky Fish"
+    export AMETHYST_CODENAME="${_codename}"
     cargo build --frozen --release
 }
 
 package() {
-    cd "$srcdir/$_pkgname-$pkgver"
-    install -Dm 755 "target/release/$pkgname" "$pkgdir/usr/bin/$pkgname"
-    install -Dm 644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
-    install -Dm 644 docs/CONFIG.md "$pkgdir/usr/share/doc/$pkgname/CONFIG.md"
+    cd "${srcdir}/${_pkgname}-${pkgver}"
+    install -Dm 755 "target/release/${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+    install -Dm 644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+    install -Dm 644 docs/CONFIG.md "${pkgdir}/usr/share/doc/${pkgname}/CONFIG.md"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,8 +11,6 @@ pkgdesc='A fast and efficient AUR helper'
 arch=('x86_64' 'aarch64')
 url="https://github.com/crystal-linux/${_pkgname}"
 license=('GPL3')
-source=("${_pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
-sha256sums=('ae1e6336177b6fa64536c9a8876ba0bac510ac528153133b67cf3f5046b43583')
 depends=(
     'git'
     'binutils'
@@ -25,6 +23,8 @@ depends=(
 makedepends=('cargo')
 conflicts=('amethyst')
 replaces=('amethyst')
+source=("${_pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('ae1e6336177b6fa64536c9a8876ba0bac510ac528153133b67cf3f5046b43583')
 
 prepare() {
     cd "${srcdir}/${_pkgname}-${pkgver}"


### PR DESCRIPTION
Hey team,

Here's another round of small improvements for the `ame` PKGBUILD:

- I changed a bit the order of the top variables to match the order of the Arch Linux PKGBUILD template. *That's just a style change*.
- As discussed with @not-my-segfault on Discord earlier that day, I modified all vars to use the `"${var}"` format (instead of the `"$var"` format), which feels cleaner and prevents [ambiguous expressions](https://stackoverflow.com/a/18136920) (even though we shouldn't encounter such expressions that much as far as PKGBUILDs are concerned). This is also the most used/common method to call variables in the other Arch/AUR PKGBUILDs globally. It is mostly a "style" improvement as well though.
- I removed the `pkgrel` from the archive's name in the `source` var. Indeed, I don't see why a `pkgrel` bump in the PKGBUILD would implies a change in the release's archive, thus I don't think it should be included in the archive's name. From my point of view, only a new release should lead to a change in the archive's content, so including the `pkgver` in its name is enough.
- I moved the `Funky Fish` codename from the `build()` function to its own dedicated `_codename` var. Indeed, as the Rust Team confirmed me, this codename is subject to change at each new release. It feels easier and safer to modify it accordingly from a var in the top of the PKGBUILD than directly in the `build()` function at each new release, in my opinion.

In addition to that, I think it could be a good idea to define a standard/template for all existing and new PKGBUILDs to be based on (in terms of format). Not like an absolute archetype to blindly follow/reproduce (as all PKGBUILDs can have their particularities) but more like a model to get inspiration from when improving or creating a PKGBUILD.
The `ame` PKGBUILD feels now clean enough to me in terms of format to endorse this "role" for now. My opinion is therefore to make all other PKGBUILDs in compliance of the `ame` PKGBUILD format (which I can do with a bit a time :smile:). 
The discussion is obviously open, don't hesitate to give me your thoughts about this. :smile_cat: 

What do you think?